### PR TITLE
Wrap the <nothing/> in h so it won't be generated as a React.createElement

### DIFF
--- a/createRenderer.js
+++ b/createRenderer.js
@@ -19,7 +19,7 @@ export default () => {
       return instance
     },
     toHtml: () => serializeHtml(root),
-    tearDown: () => render(<nothing />, parent, root).remove()
+    tearDown: () => render(h('nothing'), parent, root).remove()
   }
   return instance
 }


### PR DESCRIPTION
Hey, this is a nice little plugin that I want to use, but it seems that the `.tearDown()` method was actually beeing generated as a `React.createElement` call. Check this out: https://unpkg.com/preact-render-to-vdom@0.0.0/dist/preact-render-to-vdom.es.js
So the simple solution would be to just wrap the `<nothing/>` in a `h()`.

Let me know if there's something else going on that I wasn't careful with 😄 

Cheers!